### PR TITLE
[MLIR][Affine] Fixed nesting of loops in fusion-maximal (Issue #61820)

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
@@ -336,6 +336,10 @@ private:
 /// of loop IVs and symbols of the loop nest surrounding 'depSourceAccess' at
 /// 'loopDepth'.
 /// The slice loop bounds and associated operands are returned in 'sliceState'.
+/// If skipParallelismCheck is true, then skip the parallelism check on sibling
+/// loop. This flag will be set in cases like fusion-maximal, that must fuse if
+/// fusion is possible between a sequential and a parallel loop, where this
+/// heuristic can be ignored.
 //
 //  Backward slice example:
 //
@@ -368,6 +372,7 @@ private:
 void getComputationSliceState(Operation *depSourceOp, Operation *depSinkOp,
                               FlatAffineValueConstraints *dependenceConstraints,
                               unsigned loopDepth, bool isBackwardSlice,
+                              bool skipParallelismCheck,
                               ComputationSliceState *sliceState);
 
 /// Return the number of iterations for the `slicetripCountMap` provided.
@@ -396,7 +401,8 @@ bool buildSliceTripCountMap(
 SliceComputationResult
 computeSliceUnion(ArrayRef<Operation *> opsA, ArrayRef<Operation *> opsB,
                   unsigned loopDepth, unsigned numCommonLoops,
-                  bool isBackwardSlice, ComputationSliceState *sliceUnion);
+                  bool isBackwardSlice, bool skipParallelismCheck,
+                  ComputationSliceState *sliceUnion);
 
 /// Creates a clone of the computation contained in the loop nest surrounding
 /// 'srcOpInst', slices the iteration space of src loop based on slice bounds

--- a/mlir/include/mlir/Dialect/Affine/LoopFusionUtils.h
+++ b/mlir/include/mlir/Dialect/Affine/LoopFusionUtils.h
@@ -79,11 +79,13 @@ public:
 
   /// Construct a sibling fusion strategy targeting 'memref'. This construct
   /// should only be used for sibling fusion.
-  FusionStrategy(Value memref) : strategy(Sibling), memref(memref) {}
+  FusionStrategy(Value memref, bool maximalFusion)
+      : strategy(Sibling), maximalFusion(maximalFusion), memref(memref) {}
 
   /// Returns the fusion strategy.
   StrategyEnum getStrategy() const { return strategy; };
-
+  /// Return the Fusion Maximal state.
+  bool isMaximalFusion() const { return maximalFusion; };
   /// Returns the memref attached to this sibling fusion strategy.
   Value getSiblingFusionMemRef() const {
     assert(strategy == Sibling && "Memref is only valid for sibling fusion");
@@ -93,6 +95,8 @@ public:
 private:
   /// Fusion strategy.
   StrategyEnum strategy;
+  /// Maximal Fusion.
+  bool maximalFusion;
 
   /// Target memref for this fusion transformation. Only used for sibling
   /// fusion.

--- a/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
+++ b/mlir/lib/Dialect/Affine/Transforms/LoopFusion.cpp
@@ -1158,7 +1158,7 @@ public:
       SmallVector<ComputationSliceState, 8> depthSliceUnions;
       depthSliceUnions.resize(dstLoopDepthTest);
       unsigned maxLegalFusionDepth = 0;
-      FusionStrategy strategy(memref);
+      FusionStrategy strategy(memref, maximalFusion);
       for (unsigned i = 1; i <= dstLoopDepthTest; ++i) {
         FusionResult result =
             affine::canFuseLoops(sibAffineForOp, dstAffineForOp,

--- a/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
+++ b/mlir/lib/Dialect/Affine/Utils/LoopFusionUtils.cpp
@@ -339,7 +339,7 @@ FusionResult mlir::affine::canFuseLoops(AffineForOp srcForOp,
   // from 'forOpA' and 'forOpB'.
   SliceComputationResult sliceComputationResult = affine::computeSliceUnion(
       strategyOpsA, opsB, dstLoopDepth, numCommonLoops,
-      isSrcForOpBeforeDstForOp, srcSlice);
+      isSrcForOpBeforeDstForOp, fusionStrategy.isMaximalFusion(), srcSlice);
   if (sliceComputationResult.value == SliceComputationResult::GenericFailure) {
     LLVM_DEBUG(llvm::dbgs() << "computeSliceUnion failed\n");
     return FusionResult::FailPrecondition;


### PR DESCRIPTION
When maximal fusion is requested, slice computation can skip checking if the sibling loop is parallel or not, since maximal does not care about performance improvement. Modified slice computation to skip said check if the maximal flag is set. Modified FusionStrategy class to have a boolean member representing maximal fusion and modified slice computation methods to pass the information about the selected strategy.

**Issue**: The Issue we are trying to solve is the unnecessary nesting of loops as a result of maximal fusion #61820
**Original Pipeline**: If the sibling was sequential, then its bounds were set to be constants (the original bounds). This was forcing a nesting of the loops instead of fusion. In standard fusion (non-maximal), the strategy would have been rejected based on performance heuristics, and another iteration of bounds calculation would start. However, in maximal-fusion, this nested strategy would not be rejected.
**Solution**: When in maximal fusion, skip the check on the sibling to see if it is parallel or not. This prevents the bounds from being set as constants.
**Reasoning**: The fusion of parallel to sequential loops will produce sequential loops. It seems to be a performance-based decision to not let this happen. Hence maximal fusion can safely ignore this check.  
