### PR TITLE
[MLIR][AFFINE] Handling possible side-effects during fusion

### DIFF
--- a/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
+++ b/mlir/include/mlir/Dialect/Affine/Analysis/Utils.h
@@ -39,6 +39,7 @@ struct LoopNestStateCollector {
   SmallVector<AffineForOp, 4> forOps;
   SmallVector<Operation *, 4> loadOpInsts;
   SmallVector<Operation *, 4> storeOpInsts;
+  SmallVector<Operation *, 4> memoryEffectOpInsts;
   bool hasNonAffineRegionOp = false;
 
   // Collects load and store operations, and whether or not a region holding op
@@ -65,7 +66,8 @@ public:
     SmallVector<Operation *, 4> loads;
     // List of store op insts.
     SmallVector<Operation *, 4> stores;
-
+    // List of memory effect op insts.
+    SmallVector<Operation *, 4> memEffects;
     Node(unsigned id, Operation *op) : id(id), op(op) {}
 
     // Returns the load op count for 'memref'.


### PR DESCRIPTION
Check if the forOps have any possible side-effects and handle them during MDG formation. This commit checks if forOp contains a memoryEffect operation, which is a possible side-effects, and thus, fusion is not possible. In this commit, we modify the dependency graph initialization to add dependency edges between nodes with side-effecting ops and any other node that may be affected by it (basically the node that is accessing any memref).

Also, modified test loop-fusion-4.mlir to add a test case.

**Issue**: maximal loop fusion was not handling side-effecting ops like function calls in the loops.
**Original Pipeline**: Loops with possible side effects are classified as sequential loops. If the sibling was sequential, it led to a nesting of the loops instead of fusion. In standard fusion (non-maximal), the strategy would have been rejected based on performance heuristics, and another iteration of bounds calculation would start. However, in maximal-fusion, this strategy would not be rejected and hence loops with possible side-effects would be fused.
**Solution**: MDG initialization needed modification to handle nodes with memoryEffect ops. Edges are now added between nodes with side-effects and nodes that might get impacted.

**_INPUT_**:
```module {
  func.func @testing2(%arg0: memref<10xf32>) {
    affine.for %i = 0 to 10 {
      %0 = affine.load %arg0[%i] : memref<10xf32>
      llvm.call @g():()->()
    }
    affine.for %j = 0 to 10 {
      %0 = affine.load %arg0[%j] : memref<10xf32>
      llvm.call @f():()->()
    }
    return
  }
  llvm.func external @f()->()
  llvm.func external @g()->()
}
```
**_COMMAND_**: **mlir-opt -pass-pipeline='builtin.module(func.func(affine-loop-fusion{fusion-maximal}))'**

**_PREVIOUS OUTPUT_**:
```module {
  func.func @testing2(%arg0: memref<10xf32>) {
    affine.for %arg1 = 0 to 10 {
      affine.for %arg2 = 0 to 10 {
        %1 = affine.load %arg0[%arg2] : memref<10xf32>
        llvm.call @g() : () -> ()
      }
      %0 = affine.load %arg0[%arg1] : memref<10xf32>
      llvm.call @f() : () -> ()
    }
    return
  }
  llvm.func @f()
  llvm.func @g()
}
```
**_NEW OUTPUT_**:
```module {
  func.func @testing2(%arg0: memref<10xf32>) {
    affine.for %arg1 = 0 to 10 {
      %0 = affine.load %arg0[%arg1] : memref<10xf32>
      llvm.call @g() : () -> ()
    }
    affine.for %arg1 = 0 to 10 {
      %0 = affine.load %arg0[%arg1] : memref<10xf32>
      llvm.call @f() : () -> ()
    }
    return
  }
  llvm.func @f()
  llvm.func @g()
}
```